### PR TITLE
Fix unit tests for EpoxyDuino

### DIFF
--- a/src/MqttStreaming.h
+++ b/src/MqttStreaming.h
@@ -42,7 +42,7 @@
 #ifndef ARDUINO_STREAMING
 #define ARDUINO_STREAMING
 
-#if defined(ARDUINO) && ARDUINO >= 100
+#if (defined(ARDUINO) && ARDUINO >= 100) || defined(EPOXY_DUINO)
 #include "Arduino.h"
 #else
 #ifndef STREAMING_CONSOLE
@@ -154,7 +154,7 @@ template<typename T>
 inline Print &operator <<(Print &obj, const _BASED<T> &arg)
 { obj.print(arg.val, arg.base); return obj; }
 
-#if ARDUINO >= 18
+#if ARDUINO >= 18 || defined(EPOXY_DUINO)
 // Specialization for class _FLOAT
 // Thanks to Michael Margolis for suggesting a way
 // to accommodate Arduino 0018's floating point precision

--- a/tests/local-tests/local-tests.ino
+++ b/tests/local-tests/local-tests.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <AUnit.h>
 #include <TinyMqtt.h>
 #include <map>

--- a/tests/nowifi-tests/nowifi-tests.ino
+++ b/tests/nowifi-tests/nowifi-tests.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <AUnit.h>
 #include <TinyMqtt.h>
 #include <map>

--- a/tests/string-indexer-tests/string-indexer-tests.ino
+++ b/tests/string-indexer-tests/string-indexer-tests.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <AUnit.h>
 #include <StringIndexer.h>
 #include <map>


### PR DESCRIPTION
Requires latest version of EpoxyDuino on `develop` branch. Verified tests using the following:

```bash
$ cd TinyMqtt/tests
$ make clean
$ make tests
$ make runtests | grep failed
[...]
TestRunner summary: 1 passed, 0 failed, 0 skipped, 0 timed out, out of 1 test(s).
TestRunner summary: 7 passed, 0 failed, 0 skipped, 0 timed out, out of 7 test(s).
TestRunner summary: 9 passed, 0 failed, 0 skipped, 0 timed out, out of 9 test(s).
```
