### PR TITLE
Fix wrong string compare in string indexer

### DIFF
--- a/src/StringIndexer.h
+++ b/src/StringIndexer.h
@@ -32,7 +32,8 @@ class StringIndexer
 		{
 			for(auto it=strings.begin(); it!=strings.end(); it++)
 			{
-				if (strncmp(it->second.str.c_str(), str, len)==0)
+				if ((it->second.str.length() == len) &&
+					(strncmp(it->second.str.c_str(), str, len)==0))
 				{
 					it->second.used++;
 					return it->first;

--- a/src/TinyMqtt.h
+++ b/src/TinyMqtt.h
@@ -165,10 +165,10 @@ class MqttClient
     // TODO it seems that connected returns true in tcp mode even if
     // no negociation occured (only if tcp link is established)
 		bool connected() { return
-			(parent!=nullptr and client==nullptr) or
-			(client and client->connected()); }
+			(parent!=nullptr and tcp_client==nullptr) or
+			(tcp_client and tcp_client->connected()); }
 		void write(const char* buf, size_t length)
-		{ if (client) client->write(buf, length); }
+		{ if (tcp_client) tcp_client->write(buf, length); }
 
 		const std::string& id() const { return clientId; }
 		void id(std::string& new_id) { clientId = new_id; }
@@ -198,7 +198,7 @@ class MqttClient
 
 		// connected to local broker
 		// TODO seems to be useless
-		bool isLocal() const { return client == nullptr; }
+		bool isLocal() const { return tcp_client == nullptr; }
 
 		void dump(std::string indent="")
 		{
@@ -207,7 +207,7 @@ class MqttClient
         uint32_t ms=millis();
         Serial << indent << "+-- " << '\'' << clientId.c_str() << "' " << (connected() ? " ON " : " OFF");
         Serial << ", alive=" << alive << '/' << ms << ", ka=" << keep_alive << ' ';
-        Serial << (client && client->connected() ? "" : "dis") << "connected";
+        Serial << (tcp_client && tcp_client->connected() ? "" : "dis") << "connected";
         if (subscriptions.size())
         {
           bool c = false;
@@ -258,7 +258,7 @@ class MqttClient
 		// (this is the case when MqttBroker isn't used except here)
 		MqttBroker* parent=nullptr;		// connection to local broker
 
-		TcpClient* client=nullptr;		// connection to remote broker
+		TcpClient* tcp_client=nullptr;		// connection to remote broker
 		std::set<Topic>	subscriptions;
 		std::string clientId;
 		CallBack callback = nullptr;

--- a/src/TinyMqtt.h
+++ b/src/TinyMqtt.h
@@ -29,7 +29,7 @@
 // #define TINY_MQTT_DEBUG
 
 #ifdef TINY_MQTT_DEBUG
-  #define debug(what) { Serial << (int)__LINE__ << ' ' << what << endl; delay(100); }
+  #define debug(what) { Serial << (int)__LINE__ << ' ' << what << endl; }
 #else
   #define debug(what) {}
 #endif
@@ -151,6 +151,29 @@ class MqttClient
 		FlagCleanSession = 2,	// unsupported
 		FlagReserved = 1
 	};
+
+	enum Owner
+	{
+
+		/**
+		 * owned by application, may even be a static instance,
+		 * must never been deleted automatically (this is the default value)
+		 */
+		Application,
+
+		/**
+		 * dynamically created by a MqttBroker, which also is responsible
+		 * for cleaning it up
+		 */
+		Broker,
+
+		/**
+		 * not owned by application or broker anymore,
+		 * dear garbage collector - please clean me up
+		 */
+		GarbageCollector
+	};
+
 	public:
 	  /** Constructor. If broker is not null, this is the adress of a local broker.
 		    If you want to connect elsewhere, leave broker null and use connect() **/
@@ -213,7 +236,6 @@ class MqttClient
           bool c = false;
           Serial << " [";
           for(auto s: subscriptions)
-            (void)indent;
           {
             if (c) Serial << ", ";
             Serial << s.str().c_str();
@@ -262,6 +284,7 @@ class MqttClient
 		std::set<Topic>	subscriptions;
 		std::string clientId;
 		CallBack callback = nullptr;
+		Owner owner = Application;
 };
 
 class MqttBroker

--- a/src/TinyMqtt.h
+++ b/src/TinyMqtt.h
@@ -318,5 +318,5 @@ class MqttBroker
 		const char* auth_password = "guest";
 		State state = Disconnected;
 
-		MqttClient* broker = nullptr;
+		MqttClient* mqtt_client = nullptr;
 };


### PR DESCRIPTION
fixed a wrong string compare in StringIndexer, leading to wrong behavior of the MQTT client and server.
If you compare two strings with strncmp, you must also check if both have the same length, otherwise the check will get false positive results when a short string is the prefix of a longer string (e.g. "wind" <-> "window").