### PR TITLE
refactoring: MqttBroker, "broker" -> "mqtt_client"

### DIFF
--- a/src/TinyMqtt.h
+++ b/src/TinyMqtt.h
@@ -318,5 +318,5 @@ class MqttBroker
 		const char* auth_password = "guest";
 		State state = Disconnected;
 
-		MqttClient* broker = nullptr;
+		MqttClient* mqtt_client = nullptr;
 };


### PR DESCRIPTION
refactoring: MqttBroker contains a member variable with the name "broker". This is quite misleading and makes the code harder to understand, as this member is a mqtt _client_ -> renaming from "broker" to "mqtt_client"