### PR TITLE
More informative error on version mismatch

### DIFF
--- a/src/TinyMqtt.cpp
+++ b/src/TinyMqtt.cpp
@@ -455,7 +455,7 @@ void MqttClient::processMessage(MqttMessage* mesg)
       }
       if (header[6]!=0x04)
       {
-        debug("unknown level");
+        debug("Unsupported MQTT version (" << (int) header[6] << "), only version=4 supported" << endl);
         break;  // Level 3.1.1
       }
 


### PR DESCRIPTION
I spent a lot of time debugging my arduino, trying to figure out why my calls were all failing. Turned out to be due to the mqtt cli using v5, while this library only supports v4. By mqtt cli I mean the [hivemq one](https://hivemq.github.io/mqtt-cli/), which is the first one that shows up on google searches.

Being new to mqtt this burned me for awhile, so I'm hoping this helps the next person. Both by having this PR show up if they search, and making the error more informative.