### PR TITLE
Remove disconnect memory leak

### DIFF
--- a/src/TinyMqtt.cpp
+++ b/src/TinyMqtt.cpp
@@ -77,7 +77,7 @@ MqttClient::~MqttClient()
   debug("*** MqttClient delete()");
 }
 
-void MqttClient::close(bool bSendDisconnect)
+void MqttClient::close(bool bSendDisconnect, bool removeFromLocal)
 {
   debug("close " << id().c_str());
   resetFlag(CltFlagConnected);
@@ -92,7 +92,7 @@ void MqttClient::close(bool bSendDisconnect)
     tcp_client->stop();
   }
 
-  if (local_broker)
+  if (local_broker && removeFromLocal)
   {
     local_broker->removeClient(this);
     local_broker = nullptr;
@@ -208,8 +208,10 @@ void MqttBroker::loop()
     {
       debug("Client " << client->id().c_str() << "  Disconnected, local_broker=" << (dbg_ptr)client->local_broker);
       // Note: deleting a client not added by the broker itself will probably crash later.
+      // TODO: shouldn't this have the same checks on the delete as the constructor has?
+      //      (client->cltFlags & MqttClient::CltFlags::CltFlagToDelete)
       delete client;
-      break;
+      clients.erase(clients.begin() + i);
     }
   }
 }
@@ -656,7 +658,9 @@ void MqttClient::processMessage(MqttMessage* mesg)
       // TODO should discard any will msg
       if (not mqtt_connected()) break;
       resetFlag(CltFlagConnected);
-      close(false);
+      // don't remove from the local broker, let the next loop through the
+      // clients do that, so we can be cleaned up properly
+      close(false, false);
       bclose=false;
       break;
 

--- a/src/TinyMqtt.cpp
+++ b/src/TinyMqtt.cpp
@@ -207,11 +207,14 @@ void MqttBroker::loop()
     else
     {
       debug("Client " << client->id().c_str() << "  Disconnected, local_broker=" << (dbg_ptr)client->local_broker);
-      // Note: deleting a client not added by the broker itself will probably crash later.
-      // TODO: shouldn't this have the same checks on the delete as the constructor has?
-      //      (client->cltFlags & MqttClient::CltFlags::CltFlagToDelete)
-      delete client;
+      // Erasing the client before calling delete to ensure
+      // that if the client does a close() we don't get into a state where
+      // we try and access a deleted pointer
       clients.erase(clients.begin() + i);
+      i--;
+      if (client->cltFlags & MqttClient::CltFlags::CltFlagToDelete) {
+        delete client;
+      }
     }
   }
 }

--- a/src/TinyMqtt.h
+++ b/src/TinyMqtt.h
@@ -231,7 +231,7 @@ class MqttClient
 
     /** Should be called in main loop() */
     void loop();
-    void close(bool bSendDisconnect=true);
+    void close(bool bSendDisconnect=true, bool removeFromLocal=true);
     void setCallback(CallBack fun)
     {
       callback=fun;


### PR DESCRIPTION
When disconnecting, the client needs to be disabled and assuming it is a client created by the broker, it needs to be deleted. Previously the client was directly removed from the broker, thereby losing any reference to it and it could never be deleted.

This changes that behavior to purely invalidate the client, and the next time through the broker loop it will be properly cleaned up. This also fixes the loop code to properly erase the client from the list, and not break out early the first time it finds a disconnected client.

This doesn't fix everything, in that it seems like there's another bug that it is deleting the client without a flag check. However I'm leaving that for a separate fix.

I have tested this on my ESP32 by uploading this version of the code, running a client in an infinite loop which connects, publishes, disconnects. With the old code I can steadily see memory usage linearly leaking over time. With the new version it stays stable after the first couple times.

More in the linked issue.

Fixes #73